### PR TITLE
Delete to set alertWindow's tintColor from window's tint color, this …

### DIFF
--- a/AlertViewExamples/UIAlertViewBlockExtension/BEAlertPresenter.m
+++ b/AlertViewExamples/UIAlertViewBlockExtension/BEAlertPresenter.m
@@ -37,7 +37,6 @@
 {
     self.alertWindow = [[UIWindow alloc] initWithFrame:[UIScreen mainScreen].bounds];
     self.alertWindow.rootViewController = [[UIViewController alloc] init];
-    self.alertWindow.tintColor = [UIApplication sharedApplication].delegate.window.tintColor;
     UIWindow *topWindow = [UIApplication sharedApplication].windows.lastObject;
     self.alertWindow.windowLevel = topWindow.windowLevel + 1;
     [self.alertWindow makeKeyAndVisible];


### PR DESCRIPTION
…cause to set button color to clear when iphone setting to General>Accessibility>Increase Constrast>Darken Color is on
